### PR TITLE
Add FizzBuzz example as central start of code base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# bootstrap
+# walkflow-test
+
+This repository serves as a test bed and instructional example for the concept of "walk" and "flow" in programming.
+
+## FizzBuzz Example: The Central Starting Point
+
+The repository introduces a canonical FizzBuzz implementation as its foundational example. This example embodies the repository's name:
+
+- **Walk:** Iterating through a sequence of numbers (1 to 100).
+- **Flow:** Conditional branching to determine output based on divisibility.
+
+The example is implemented in Python in the file `fizzbuzz_walkflow.py` and can be run directly to observe the classic FizzBuzz output.
+
+This simple yet illustrative example sets the tone for exploring programmatic flows and iterations within the repository.
+
+---
+
+To run the example:
+
+```bash
+python fizzbuzz_walkflow.py
+```

--- a/fizzbuzz_walkflow.py
+++ b/fizzbuzz_walkflow.py
@@ -1,0 +1,19 @@
+"""
+FizzBuzz example illustrating the 'walk' (iteration) and 'flow' (conditional branching) concepts.
+This script prints numbers from 1 to 100, substituting multiples of 3 with 'Fizz',
+multiples of 5 with 'Buzz', and multiples of both with 'FizzBuzz'.
+"""
+
+def fizzbuzz_walkflow(start=1, end=100):
+    """Walk through numbers from start to end and flow through conditions to print FizzBuzz."""
+    for number in range(start, end + 1):  # Walk: iterate through the sequence
+        output = ''
+        if number % 3 == 0:  # Flow: condition for multiples of 3
+            output += 'Fizz'
+        if number % 5 == 0:  # Flow: condition for multiples of 5
+            output += 'Buzz'
+        print(output or number)
+
+
+if __name__ == '__main__':
+    fizzbuzz_walkflow()


### PR DESCRIPTION
Closes #11

Created by WalkFlow after caller confirmation.

Add an example implementation of FizzBuzz to serve as the central starting point of the walkflow-test repository, reflecting the concept of 'walk' and 'flow' as the repository name suggests. The implementation uses Python to illustrate the 'walk' as iteration and 'flow' as conditional branching, embodying the repository's thematic naming. The README is updated to reference this example.

### Generated Changes
- `fizzbuzz_walkflow.py`: Add fizzbuzz_walkflow.py implementing FizzBuzz with thematic comments on 'walk' and 'flow'.
- `README.md`: Update README.md to introduce the FizzBuzz example as the central starting point, explaining the 'walk' and 'flow' metaphor.