### PR TITLE
Implement simple FizzBuzz example with tests

### DIFF
--- a/fizzbuzz.py
+++ b/fizzbuzz.py
@@ -1,0 +1,13 @@
+def fizzbuzz(n):
+    if n % 15 == 0:
+        return "FizzBuzz"
+    elif n % 3 == 0:
+        return "Fizz"
+    elif n % 5 == 0:
+        return "Buzz"
+    else:
+        return str(n)
+
+
+def fizzbuzz_list(start=1, end=100):
+    return [fizzbuzz(i) for i in range(start, end + 1)]

--- a/test_fizzbuzz.py
+++ b/test_fizzbuzz.py
@@ -1,0 +1,33 @@
+import unittest
+from fizzbuzz import fizzbuzz, fizzbuzz_list
+
+class TestFizzBuzz(unittest.TestCase):
+    def test_fizz(self):
+        self.assertEqual(fizzbuzz(3), "Fizz")
+        self.assertEqual(fizzbuzz(6), "Fizz")
+
+    def test_buzz(self):
+        self.assertEqual(fizzbuzz(5), "Buzz")
+        self.assertEqual(fizzbuzz(10), "Buzz")
+
+    def test_fizzbuzz(self):
+        self.assertEqual(fizzbuzz(15), "FizzBuzz")
+        self.assertEqual(fizzbuzz(30), "FizzBuzz")
+
+    def test_neither(self):
+        self.assertEqual(fizzbuzz(1), "1")
+        self.assertEqual(fizzbuzz(2), "2")
+
+    def test_fizzbuzz_list_length(self):
+        result = fizzbuzz_list()
+        self.assertEqual(len(result), 100)
+
+    def test_fizzbuzz_list_content(self):
+        result = fizzbuzz_list()
+        self.assertEqual(result[0], "1")
+        self.assertEqual(result[2], "Fizz")  # 3rd element
+        self.assertEqual(result[4], "Buzz")  # 5th element
+        self.assertEqual(result[14], "FizzBuzz")  # 15th element
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #33

Created by WalkFlow after caller confirmation.

Add a simple implementation of the FizzBuzz problem to the walkflow-test repository, including corresponding tests to verify correctness. The implementation covers numbers 1 through 100, printing 'Fizz' for multiples of 3, 'Buzz' for multiples of 5, and 'FizzBuzz' for multiples of both. Automated tests verify correctness for various input scenarios.

### Generated Changes
- `fizzbuzz.py`: Add fizzbuzz.py with fizzbuzz function and fizzbuzz_list for range 1 to 100.
- `test_fizzbuzz.py`: Add test_fizzbuzz.py with unittest cases for fizzbuzz function and fizzbuzz_list.