### PR TITLE
Add test suite for FizzBuzz implementation

### DIFF
--- a/fizzbuzz.js
+++ b/fizzbuzz.js
@@ -1,0 +1,8 @@
+function fizzBuzz(n) {
+  if (n % 15 === 0) return 'FizzBuzz';
+  if (n % 3 === 0) return 'Fizz';
+  if (n % 5 === 0) return 'Buzz';
+  return n.toString();
+}
+
+module.exports = fizzBuzz;

--- a/fizzbuzz.test.js
+++ b/fizzbuzz.test.js
@@ -1,0 +1,29 @@
+const fizzBuzz = require('./fizzbuzz');
+
+describe('FizzBuzz function', () => {
+  test.each([
+    [1, '1'],
+    [2, '2'],
+    [3, 'Fizz'],
+    [4, '4'],
+    [5, 'Buzz'],
+    [6, 'Fizz'],
+    [10, 'Buzz'],
+    [15, 'FizzBuzz'],
+    [30, 'FizzBuzz'],
+    [97, '97'],
+    [100, 'Buzz']
+  ])('fizzBuzz(%i) should return %s', (input, expected) => {
+    expect(fizzBuzz(input)).toBe(expected);
+  });
+
+  test('fizzBuzz returns correct values for numbers 1 to 100', () => {
+    for (let i = 1; i <= 100; i++) {
+      let expected = '';
+      if (i % 3 === 0) expected += 'Fizz';
+      if (i % 5 === 0) expected += 'Buzz';
+      if (expected === '') expected = i.toString();
+      expect(fizzBuzz(i)).toBe(expected);
+    }
+  });
+});


### PR DESCRIPTION
Closes #53

Created by WalkFlow after caller confirmation.

This PR adds a Jest-based test suite to verify the correctness of a FizzBuzz implementation. The tests cover all classic FizzBuzz rules for numbers 1 through 100, ensuring that the function returns 'Fizz', 'Buzz', 'FizzBuzz', or the number itself as appropriate.

### Generated Changes
- `fizzbuzz.js`: Add a simple FizzBuzz implementation to test.
- `fizzbuzz.test.js`: Add Jest test suite to verify FizzBuzz implementation correctness.